### PR TITLE
extremely dirty fix for a skullboard message being >100 messages old.

### DIFF
--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -46,6 +46,9 @@ module.exports = {
             console.log('here')
             return;
         }
+        
+        // Check if the message was sent within the last 14 days. If not, return. Justice for GalaxyCat.
+        if (reaction.message.createdTimestamp < new Date().setDate(new Date().getDate() - 14)) return;
 
         // 
         if (reaction._emoji.name === "💀" && reaction.count >= 7 && reaction.message.channelId != process.env.SKULLBOARD_CHANNEL_ID) {

--- a/src/events/messageReactionRemove.js
+++ b/src/events/messageReactionRemove.js
@@ -33,6 +33,9 @@ module.exports = {
             title = `💀💀💀💀 ${reaction.count}`
 
         }
+        
+        // Check if the message was sent within the last 14 days. If not, return. Justice for GalaxyCat.
+        if (reaction.message.createdTimestamp < new Date().setDate(new Date().getDate() - 14)) return;
 
         if (reaction._emoji.name === "💀" && reaction.count >= 6 && reaction.message.channelId != process.env.SKULLBOARD_CHANNEL_ID) {
             console.log("test");


### PR DESCRIPTION
stops tracking reactions to messages over 14 days old